### PR TITLE
Workaround for undiscovered dependencies in external libraries

### DIFF
--- a/src/Model/Carrier.php
+++ b/src/Model/Carrier.php
@@ -63,7 +63,6 @@ class Carrier extends AbstractCarrier implements CarrierInterface
      * @param ResultFactory $rateResultFactory
      * @param MethodFactory $rateMethodFactory
      * @param Rounder $rounder
-     * @param LibCarrier $carrier
      * @param array $data
      */
     public function __construct(
@@ -73,7 +72,6 @@ class Carrier extends AbstractCarrier implements CarrierInterface
         ResultFactory $rateResultFactory,
         MethodFactory $rateMethodFactory,
         Rounder $rounder,
-        LibCarrier $carrier,
         array $data = []
     ) {
         $this->rateResultFactory = $rateResultFactory;

--- a/src/Test/Unit/Model/CarrierTest.php
+++ b/src/Test/Unit/Model/CarrierTest.php
@@ -102,6 +102,7 @@ class CarrierTest extends \PHPUnit_Framework_TestCase
             $this->rounder,
             $this->libCarrier
         );
+        $this->model->setCarrier($this->libCarrier);
     }
 
     public function testGetAllowedMethods()

--- a/src/Test/Unit/Model/CarrierTest.php
+++ b/src/Test/Unit/Model/CarrierTest.php
@@ -99,8 +99,7 @@ class CarrierTest extends \PHPUnit_Framework_TestCase
             $logger,
             $this->rateResultFactory,
             $this->rateMethodFactory,
-            $this->rounder,
-            $this->libCarrier
+            $this->rounder
         );
         $this->model->setCarrier($this->libCarrier);
     }

--- a/src/composer.json
+++ b/src/composer.json
@@ -2,7 +2,7 @@
   "name": "meanbee/module-royalmail",
   "description": "A Royal Mail shipping integration for Magento 2.",
   "type": "magento2-module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": [
     "OSL-3.0"
   ],

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Meanbee_RoyalMail" setup_version="0.1.0">
+    <module name="Meanbee_RoyalMail" setup_version="0.1.1">
     </module>
 </config>


### PR DESCRIPTION
This fixes #3.

The workaround implements a getter/setter for the external Carrier class. Which by default will instantiate the class itself, rather than using Magento's DI.